### PR TITLE
Add the option to configure whether text should be trimmed 

### DIFF
--- a/src/XmlToArrayConfig.php
+++ b/src/XmlToArrayConfig.php
@@ -6,6 +6,8 @@ class XmlToArrayConfig
 {
     private bool $detachNamespaces = false;
 
+    private array $trimExcept = [];
+
     public function getDetachNamespaces(): bool
     {
         return $this->detachNamespaces;
@@ -14,6 +16,18 @@ class XmlToArrayConfig
     public function setDetachNamespaces(bool $detachNamespaces): self
     {
         $this->detachNamespaces = $detachNamespaces;
+
+        return $this;
+    }
+
+    public function getTrimExcept(): array
+    {
+        return $this->trimExcept;
+    }
+
+    public function setTrimExcept(array $except): self
+    {
+        $this->trimExcept = $except;
 
         return $this;
     }

--- a/src/XmlToArrayConfig.php
+++ b/src/XmlToArrayConfig.php
@@ -6,7 +6,7 @@ class XmlToArrayConfig
 {
     private bool $detachNamespaces = false;
 
-    private array $trimExcept = [];
+    private bool $trimText = true;
 
     public function getDetachNamespaces(): bool
     {
@@ -20,14 +20,14 @@ class XmlToArrayConfig
         return $this;
     }
 
-    public function getTrimExcept(): array
+    public function getTrimText(): bool
     {
-        return $this->trimExcept;
+        return $this->trimText;
     }
 
-    public function setTrimExcept(array $except): self
+    public function setTrimText(bool $trimText): self
     {
-        $this->trimExcept = $except;
+        $this->trimText = $trimText;
 
         return $this;
     }

--- a/src/XmlToArrayConverter.php
+++ b/src/XmlToArrayConverter.php
@@ -75,7 +75,7 @@ class XmlToArrayConverter
         // `<email></email>` has 0 child nodes, but we still want the value to be
         // present (even if it's an empty string). It will result in `['#text' => '']`.
         $array['#text'] = count($childNodes) === 1 && $childNodes[0] instanceof DOMText
-            ? $this->config->getTrimText() ? trim($childNodes[0]->textContent) : $childNodes[0]->textContent
+            ? ($this->config->getTrimText() ? trim($childNodes[0]->textContent) : $childNodes[0]->textContent)
             : '';
 
         // Here we process DOMElement child nodes. The results are grouped by the tag name.

--- a/src/XmlToArrayConverter.php
+++ b/src/XmlToArrayConverter.php
@@ -75,7 +75,7 @@ class XmlToArrayConverter
         // `<email></email>` has 0 child nodes, but we still want the value to be
         // present (even if it's an empty string). It will result in `['#text' => '']`.
         $array['#text'] = count($childNodes) === 1 && $childNodes[0] instanceof DOMText
-            ? trim($childNodes[0]->textContent)
+            ? $this->trim($domElement, $childNodes[0])
             : '';
 
         // Here we process DOMElement child nodes. The results are grouped by the tag name.
@@ -128,5 +128,17 @@ class XmlToArrayConverter
         }
 
         return $childNodes;
+    }
+
+    /**
+     * @param DOMElement $domElement
+     * @param DOMText $domText
+     * @return string
+     */
+    private function trim(DOMElement $domElement, DOMText $domText): string
+    {
+        return in_array($this->getElementName($domElement), $this->config->getTrimExcept())
+            ? $domElement->textContent
+            : trim($domElement->textContent);
     }
 }

--- a/src/XmlToArrayConverter.php
+++ b/src/XmlToArrayConverter.php
@@ -138,7 +138,7 @@ class XmlToArrayConverter
     private function trim(DOMElement $domElement, DOMText $domText): string
     {
         return in_array($this->getElementName($domElement), $this->config->getTrimExcept())
-            ? $domElement->textContent
-            : trim($domElement->textContent);
+            ? $domText->textContent
+            : trim($domText->textContent);
     }
 }

--- a/src/XmlToArrayConverter.php
+++ b/src/XmlToArrayConverter.php
@@ -75,7 +75,7 @@ class XmlToArrayConverter
         // `<email></email>` has 0 child nodes, but we still want the value to be
         // present (even if it's an empty string). It will result in `['#text' => '']`.
         $array['#text'] = count($childNodes) === 1 && $childNodes[0] instanceof DOMText
-            ? $this->trim($domElement, $childNodes[0])
+            ? $this->config->getTrimText() ? trim($childNodes[0]->textContent) : $childNodes[0]->textContent
             : '';
 
         // Here we process DOMElement child nodes. The results are grouped by the tag name.
@@ -128,17 +128,5 @@ class XmlToArrayConverter
         }
 
         return $childNodes;
-    }
-
-    /**
-     * @param DOMElement $domElement
-     * @param DOMText $domText
-     * @return string
-     */
-    private function trim(DOMElement $domElement, DOMText $domText): string
-    {
-        return in_array($domElement->tagName, $this->config->getTrimExcept())
-            ? $domText->textContent
-            : trim($domText->textContent);
     }
 }

--- a/src/XmlToArrayConverter.php
+++ b/src/XmlToArrayConverter.php
@@ -137,7 +137,7 @@ class XmlToArrayConverter
      */
     private function trim(DOMElement $domElement, DOMText $domText): string
     {
-        return in_array($this->getElementName($domElement), $this->config->getTrimExcept())
+        return in_array($domElement->tagName, $this->config->getTrimExcept())
             ? $domText->textContent
             : trim($domText->textContent);
     }

--- a/tests/XmlToArrayConfigTest.php
+++ b/tests/XmlToArrayConfigTest.php
@@ -16,9 +16,9 @@ class XmlToArrayConfigTest extends TestCase
     }
 
     /** @test */
-    public function trim_except()
+    public function trim_text()
     {
-        $this->assertSame([], (new XmlToArrayConfig())->getTrimExcept());
-        $this->assertSame(['foo', 'bar'], (new XmlToArrayConfig())->setTrimExcept(['foo', 'bar'])->getTrimExcept());
+        $this->assertSame(true, (new XmlToArrayConfig())->getTrimText());
+        $this->assertSame(false, (new XmlToArrayConfig())->setTrimText(false)->getTrimText());
     }
 }

--- a/tests/XmlToArrayConfigTest.php
+++ b/tests/XmlToArrayConfigTest.php
@@ -14,4 +14,11 @@ class XmlToArrayConfigTest extends TestCase
         $this->assertFalse((new XmlToArrayConfig())->setDetachNamespaces(false)->getDetachNamespaces());
         $this->assertTrue((new XmlToArrayConfig())->setDetachNamespaces(true)->getDetachNamespaces());
     }
+
+    /** @test */
+    public function trim_except()
+    {
+        $this->assertSame([], (new XmlToArrayConfig())->getTrimExcept());
+        $this->assertSame(['foo', 'bar'], (new XmlToArrayConfig())->setTrimExcept(['foo', 'bar'])->getTrimExcept());
+    }
 }

--- a/tests/XmlToArrayConverterTest.php
+++ b/tests/XmlToArrayConverterTest.php
@@ -205,9 +205,6 @@ XML;
         $xml = <<<'XML'
 <test:root xmlns:foo="http://example.com/foo" xmlns:bar="http://example.com/bar" xmlns:test="http://example.com/test">
     <foo> B </foo>
-    <bar>
-        C
-    </bar>
 </test:root>
 XML;
 
@@ -219,56 +216,11 @@ XML;
                         '#text' => ' B ',
                     ],
                 ],
-                'bar' => [
-                    [
-                        '#text' => 'C',
-                    ],
-                ],
             ],
         ];
 
         $config = new XmlToArrayConfig();
-        $config->setTrimExcept(['foo']);
-
-        $this->assertSame($expected, (new XmlToArrayConverter($config))->convert($xml));
-    }
-
-    /** @test */
-    public function does_not_trim_values_with_namespaces_when_node_value_should_not_be_trimmed(): void
-    {
-        $xml = <<<'XML'
-<test:root xmlns:foo="http://example.com/foo" xmlns:bar="http://example.com/bar" xmlns:test="http://example.com/test">
-    <foo:shouldTrim> one </foo:shouldTrim>
-    <foo:shouldNotTrim> two </foo:shouldNotTrim>
-    <bar>
-        C
-    </bar>
-</test:root>
-XML;
-
-        $expected = [
-            'test:root' => [
-                '#text' => '',
-                'foo:shouldTrim' => [
-                    [
-                        '#text' => 'one',
-                    ],
-                ],
-                'foo:shouldNotTrim' => [
-                    [
-                        '#text' => ' two ',
-                    ],
-                ],
-                'bar' => [
-                    [
-                        '#text' => 'C',
-                    ],
-                ],
-            ],
-        ];
-
-        $config = new XmlToArrayConfig();
-        $config->setTrimExcept(['foo:shouldNotTrim']);
+        $config->setTrimText(false);
 
         $this->assertSame($expected, (new XmlToArrayConverter($config))->convert($xml));
     }

--- a/tests/XmlToArrayConverterTest.php
+++ b/tests/XmlToArrayConverterTest.php
@@ -200,6 +200,40 @@ XML;
     }
 
     /** @test */
+    public function does_not_trim_values_when_node_value_should_not_be_trimmed(): void
+    {
+        $xml = <<<'XML'
+<test:root xmlns:foo="http://example.com/foo" xmlns:bar="http://example.com/bar" xmlns:test="http://example.com/test">
+    <foo> B </foo>
+    <bar>
+        C
+    </bar>
+</test:root>
+XML;
+
+        $expected = [
+            'test:root' => [
+                '#text' => '',
+                'foo' => [
+                    [
+                        '#text' => ' B ',
+                    ],
+                ],
+                'bar' => [
+                    [
+                        '#text' => 'C',
+                    ],
+                ],
+            ],
+        ];
+
+        $config = new XmlToArrayConfig();
+        $config->setTrimExcept(['foo']);
+
+        $this->assertSame($expected, (new XmlToArrayConverter($config))->convert($xml));
+    }
+
+    /** @test */
     public function handles_namespaced_nodes_correctly_when_detach_namespaces_is_true()
     {
         $xml = <<<'XML'

--- a/tests/XmlToArrayConverterTest.php
+++ b/tests/XmlToArrayConverterTest.php
@@ -234,6 +234,46 @@ XML;
     }
 
     /** @test */
+    public function does_not_trim_values_with_namespaces_when_node_value_should_not_be_trimmed(): void
+    {
+        $xml = <<<'XML'
+<test:root xmlns:foo="http://example.com/foo" xmlns:bar="http://example.com/bar" xmlns:test="http://example.com/test">
+    <foo:shouldTrim> one </foo:shouldTrim>
+    <foo:shouldNotTrim> two </foo:shouldNotTrim>
+    <bar>
+        C
+    </bar>
+</test:root>
+XML;
+
+        $expected = [
+            'test:root' => [
+                '#text' => '',
+                'foo:shouldTrim' => [
+                    [
+                        '#text' => 'one',
+                    ],
+                ],
+                'foo:shouldNotTrim' => [
+                    [
+                        '#text' => ' two ',
+                    ],
+                ],
+                'bar' => [
+                    [
+                        '#text' => 'C',
+                    ],
+                ],
+            ],
+        ];
+
+        $config = new XmlToArrayConfig();
+        $config->setTrimExcept(['foo:shouldNotTrim']);
+
+        $this->assertSame($expected, (new XmlToArrayConverter($config))->convert($xml));
+    }
+
+    /** @test */
     public function handles_namespaced_nodes_correctly_when_detach_namespaces_is_true()
     {
         $xml = <<<'XML'

--- a/tests/XmlToArrayConverterTest.php
+++ b/tests/XmlToArrayConverterTest.php
@@ -200,7 +200,7 @@ XML;
     }
 
     /** @test */
-    public function does_not_trim_values_when_node_value_should_not_be_trimmed(): void
+    public function does_not_trim_values_when_trim_text_is_false(): void
     {
         $xml = <<<'XML'
 <test:root xmlns:foo="http://example.com/foo" xmlns:bar="http://example.com/bar" xmlns:test="http://example.com/test">
@@ -221,6 +221,32 @@ XML;
 
         $config = new XmlToArrayConfig();
         $config->setTrimText(false);
+
+        $this->assertSame($expected, (new XmlToArrayConverter($config))->convert($xml));
+    }
+
+    /** @test */
+    public function trims_values_when_trim_text_is_true(): void
+    {
+        $xml = <<<'XML'
+<test:root xmlns:foo="http://example.com/foo" xmlns:bar="http://example.com/bar" xmlns:test="http://example.com/test">
+    <foo> B </foo>
+</test:root>
+XML;
+
+        $expected = [
+            'test:root' => [
+                '#text' => '',
+                'foo' => [
+                    [
+                        '#text' => 'B',
+                    ],
+                ],
+            ],
+        ];
+
+        $config = new XmlToArrayConfig();
+        $config->setTrimText(true);
 
         $this->assertSame($expected, (new XmlToArrayConverter($config))->convert($xml));
     }


### PR DESCRIPTION
This PR adds a new option to the `XmlToArrayConfig`.

Now, it makes it possible to tell whether to trim the text. This option can be adjusted using the `setTrimText(bool)` method.